### PR TITLE
Add tree-sitter TypeScript and Flow grammars

### DIFF
--- a/grammars/tree-sitter-flow.cson
+++ b/grammars/tree-sitter-flow.cson
@@ -11,7 +11,7 @@ fileTypes: [
   'jsx.flow'
 ]
 
-firstLineMatch: '@flow'
+contentRegExp: '(/\\*([^*]|\\*[^/])*|//.*)@flow'
 
 comments:
   start: '// '

--- a/grammars/tree-sitter-flow.cson
+++ b/grammars/tree-sitter-flow.cson
@@ -1,0 +1,116 @@
+id: 'flow-javascript'
+name: 'Flow JavaScript'
+type: 'tree-sitter'
+parser: 'tree-sitter-typescript'
+
+fileTypes: [
+  "js",
+  "flow.js",
+  "flow.jsx",
+]
+
+firstLineMatch: '@flow'
+
+comments:
+  start: '// '
+
+folds:
+  delimiters: [
+    ['{', '}']
+    ['(', ')']
+    ['[', ']']
+    ['jsx_opening_element', 'jsx_closing_element']
+    ['<', '>']
+  ]
+
+  tokens: [
+    ['comment', 2, 2]
+    ['template_string', 1, 1]
+  ]
+
+scopes:
+  'program': 'source.js'
+  'ERROR': 'syntax-error'
+
+  'property_identifier': 'variable.other.object.property'
+
+  'class > identifier': 'support.storage.type'
+  'type_identifier': 'support.storage.type'
+  'predefined_type': 'support.storage.type'
+
+  'function > identifier': 'entity.name.function'
+  'call_expression > identifier': 'entity.name.function'
+  'method_definition > property_identifier': 'entity.name.function'
+  'call_expression > member_expression > property_identifier': 'entity.name.function'
+
+  'new_expression > call_expression > identifier': 'meta.class.instance.constructor'
+
+  'number': 'constant.numeric.decimal'
+  'string': 'string.quoted.single'
+  'regex': 'string.regexp'
+  'template_string': 'string.quoted.template'
+  'undefined': 'constant.language'
+  'null': 'constant.language.null'
+  'true': 'constant.language.boolean.true'
+  'false': 'constant.language.boolean.false'
+  'comment': 'comment.block'
+
+  '"("': 'punctuation.definition.parameters.begin.bracket.round'
+  '")"': 'punctuation.definition.parameters.end.bracket.round'
+  '"{"': 'punctuation.definition.function.body.begin.bracket.curly'
+  '"}"': 'punctuation.definition.function.body.end.bracket.curly'
+
+  '"var"': 'storage.modifier'
+  '"declare"': 'storage.modifier'
+  '"let"': 'storage.modifier'
+  '"const"': 'storage.modifier'
+  '"static"': 'storage.modifier'
+  '"public"': 'storage.modifier'
+  '"private"': 'storage.modifier'
+  'readonly': 'storage.modifier'
+  '"class"': 'storage.type.class'
+  '"function"': 'storage.type.function'
+  '"type"': 'storage.type.type'
+
+  '"+"': 'keyword.operator'
+  '"-"': 'keyword.operator'
+  '"*"': 'keyword.operator'
+  '"/"': 'keyword.operator'
+  '"in"': 'keyword.operator.in'
+  '"instanceof"': 'keyword.operator.instanceof'
+  '"of"': 'keyword.operator.of'
+  '"new"': 'keyword.operator.new'
+  '"typeof"': 'keyword.operator.typeof'
+
+  '"get"': 'keyword.operator.setter'
+  '"set"': 'keyword.operator.setter'
+
+  '"."': 'meta.delimiter.property.period'
+  '","': 'meta.delimiter.object.comma'
+
+  '"if"': 'keyword.control'
+  '"do"': 'keyword.control'
+  '"else"': 'keyword.control'
+  '"while"': 'keyword.control'
+  '"for"': 'keyword.control'
+  '"return"': 'keyword.control'
+  '"break"': 'keyword.control'
+  '"continue"': 'keyword.control'
+  '"throw"': 'keyword.control'
+  '"try"': 'keyword.control'
+  '"catch"': 'keyword.control'
+  '"finally"': 'keyword.control'
+  '"switch"': 'keyword.control'
+  '"case"': 'keyword.control'
+  '"default"': 'keyword.control'
+  '"export"': 'keyword.control'
+  '"import"': 'keyword.control'
+  '"from"': 'keyword.control'
+  '"yield"': 'keyword.control'
+  '"async"': 'keyword.control'
+  '"await"': 'keyword.control'
+
+  'jsx_attribute': 'entity.other.attribute-name'
+  'jsx_opening_element > identifier': 'entity.name.tag'
+  'jsx_closing_element > identifier': 'entity.name.tag'
+  'jsx_self_closing_element > identifier': 'entity.name.tag'

--- a/grammars/tree-sitter-flow.cson
+++ b/grammars/tree-sitter-flow.cson
@@ -18,10 +18,10 @@ comments:
 
 folds: [
   {
-    type: ['comment', 'template_string']
+    type: 'comment'
   }
   {
-    type: 'jsx_element'
+    type: ['jsx_element', 'template_string']
     start: {index: 0}
     end: {index: -1}
   }

--- a/grammars/tree-sitter-flow.cson
+++ b/grammars/tree-sitter-flow.cson
@@ -4,9 +4,11 @@ type: 'tree-sitter'
 parser: 'tree-sitter-typescript'
 
 fileTypes: [
-  "js",
-  "flow.js",
-  "flow.jsx",
+  'js'
+  'flow.js'
+  'flow.jsx'
+  'js.flow'
+  'jsx.flow'
 ]
 
 firstLineMatch: '@flow'
@@ -14,19 +16,42 @@ firstLineMatch: '@flow'
 comments:
   start: '// '
 
-folds:
-  delimiters: [
-    ['{', '}']
-    ['(', ')']
-    ['[', ']']
-    ['jsx_opening_element', 'jsx_closing_element']
-    ['<', '>']
-  ]
-
-  tokens: [
-    ['comment', 2, 2]
-    ['template_string', 1, 1]
-  ]
+folds: [
+  {
+    type: ['comment', 'template_string']
+  }
+  {
+    type: 'jsx_element'
+    start: {index: 0}
+    end: {index: -1}
+  }
+  {
+    type: 'jsx_self_closing_element'
+    start: {index: 1}
+    end: {index: -2}
+  }
+  {
+    type: [
+      'object_type'
+      'template_arguments'
+      'template_parameters'
+    ]
+    start: {index: 0}
+    end: {index: -1}
+  }
+  {
+    start: {index: 0, type: '{'}
+    end: {index: -1, type: '}'}
+  }
+  {
+    start: {index: 0, type: '['}
+    end: {index: -1, type: ']'}
+  }
+  {
+    start: {index: 0, type: '('}
+    end: {index: -1, type: ')'}
+  }
+]
 
 scopes:
   'program': 'source.js'
@@ -110,7 +135,7 @@ scopes:
   '"async"': 'keyword.control'
   '"await"': 'keyword.control'
 
-  'jsx_attribute': 'entity.other.attribute-name'
+  'jsx_attribute > property_identifier': 'entity.other.attribute-name'
   'jsx_opening_element > identifier': 'entity.name.tag'
   'jsx_closing_element > identifier': 'entity.name.tag'
   'jsx_self_closing_element > identifier': 'entity.name.tag'

--- a/grammars/tree-sitter-typescript.cson
+++ b/grammars/tree-sitter-typescript.cson
@@ -3,24 +3,47 @@ name: 'TypeScript'
 type: 'tree-sitter'
 parser: 'tree-sitter-typescript'
 
-fileTypes: ["ts", "tsx", "js.flow"]
+fileTypes: ['ts', 'tsx']
 
 comments:
   start: '// '
 
-folds:
-  delimiters: [
-    ['{', '}']
-    ['(', ')']
-    ['[', ']']
-    ['jsx_opening_element', 'jsx_closing_element']
-    ['<', '>']
-  ]
-
-  tokens: [
-    ['comment', 2, 2]
-    ['template_string', 1, 1]
-  ]
+folds: [
+  {
+    type: ['comment', 'template_string']
+  }
+  {
+    type: 'jsx_element'
+    start: {index: 0}
+    end: {index: -1}
+  }
+  {
+    type: 'jsx_self_closing_element'
+    start: {index: 1}
+    end: {index: -2}
+  }
+  {
+    type: [
+      'object_type'
+      'template_arguments'
+      'template_parameters'
+    ]
+    start: {index: 0}
+    end: {index: -1}
+  }
+  {
+    start: {index: 0, type: '{'}
+    end: {index: -1, type: '}'}
+  }
+  {
+    start: {index: 0, type: '['}
+    end: {index: -1, type: ']'}
+  }
+  {
+    start: {index: 0, type: '('}
+    end: {index: -1, type: ')'}
+  }
+]
 
 scopes:
   'program': 'source.js'
@@ -104,7 +127,7 @@ scopes:
   '"async"': 'keyword.control'
   '"await"': 'keyword.control'
 
-  'jsx_attribute': 'entity.other.attribute-name'
+  'jsx_attribute > property_identifier': 'entity.other.attribute-name'
   'jsx_opening_element > identifier': 'entity.name.tag'
   'jsx_closing_element > identifier': 'entity.name.tag'
   'jsx_self_closing_element > identifier': 'entity.name.tag'

--- a/grammars/tree-sitter-typescript.cson
+++ b/grammars/tree-sitter-typescript.cson
@@ -1,0 +1,110 @@
+id: 'typescript'
+name: 'TypeScript'
+type: 'tree-sitter'
+parser: 'tree-sitter-typescript'
+
+fileTypes: ["ts", "tsx", "js.flow"]
+
+comments:
+  start: '// '
+
+folds:
+  delimiters: [
+    ['{', '}']
+    ['(', ')']
+    ['[', ']']
+    ['jsx_opening_element', 'jsx_closing_element']
+    ['<', '>']
+  ]
+
+  tokens: [
+    ['comment', 2, 2]
+    ['template_string', 1, 1]
+  ]
+
+scopes:
+  'program': 'source.js'
+  'ERROR': 'syntax-error'
+
+  'property_identifier': 'variable.other.object.property'
+
+  'class > identifier': 'support.storage.type'
+  'type_identifier': 'support.storage.type'
+  'predefined_type': 'support.storage.type'
+
+  'function > identifier': 'entity.name.function'
+  'call_expression > identifier': 'entity.name.function'
+  'method_definition > property_identifier': 'entity.name.function'
+  'call_expression > member_expression > property_identifier': 'entity.name.function'
+
+  'new_expression > call_expression > identifier': 'meta.class.instance.constructor'
+
+  'number': 'constant.numeric.decimal'
+  'string': 'string.quoted.single'
+  'regex': 'string.regexp'
+  'template_string': 'string.quoted.template'
+  'undefined': 'constant.language'
+  'null': 'constant.language.null'
+  'true': 'constant.language.boolean.true'
+  'false': 'constant.language.boolean.false'
+  'comment': 'comment.block'
+
+  '"("': 'punctuation.definition.parameters.begin.bracket.round'
+  '")"': 'punctuation.definition.parameters.end.bracket.round'
+  '"{"': 'punctuation.definition.function.body.begin.bracket.curly'
+  '"}"': 'punctuation.definition.function.body.end.bracket.curly'
+
+  '"var"': 'storage.modifier'
+  '"declare"': 'storage.modifier'
+  '"let"': 'storage.modifier'
+  '"const"': 'storage.modifier'
+  '"static"': 'storage.modifier'
+  '"public"': 'storage.modifier'
+  '"private"': 'storage.modifier'
+  'readonly': 'storage.modifier'
+  '"class"': 'storage.type.class'
+  '"function"': 'storage.type.function'
+  '"type"': 'storage.type.type'
+
+  '"+"': 'keyword.operator'
+  '"-"': 'keyword.operator'
+  '"*"': 'keyword.operator'
+  '"/"': 'keyword.operator'
+  '"in"': 'keyword.operator.in'
+  '"instanceof"': 'keyword.operator.instanceof'
+  '"of"': 'keyword.operator.of'
+  '"new"': 'keyword.operator.new'
+  '"typeof"': 'keyword.operator.typeof'
+
+  '"get"': 'keyword.operator.setter'
+  '"set"': 'keyword.operator.setter'
+
+  '"."': 'meta.delimiter.property.period'
+  '","': 'meta.delimiter.object.comma'
+
+  '"if"': 'keyword.control'
+  '"do"': 'keyword.control'
+  '"else"': 'keyword.control'
+  '"while"': 'keyword.control'
+  '"for"': 'keyword.control'
+  '"return"': 'keyword.control'
+  '"break"': 'keyword.control'
+  '"continue"': 'keyword.control'
+  '"throw"': 'keyword.control'
+  '"try"': 'keyword.control'
+  '"catch"': 'keyword.control'
+  '"finally"': 'keyword.control'
+  '"switch"': 'keyword.control'
+  '"case"': 'keyword.control'
+  '"default"': 'keyword.control'
+  '"export"': 'keyword.control'
+  '"import"': 'keyword.control'
+  '"from"': 'keyword.control'
+  '"yield"': 'keyword.control'
+  '"async"': 'keyword.control'
+  '"await"': 'keyword.control'
+
+  'jsx_attribute': 'entity.other.attribute-name'
+  'jsx_opening_element > identifier': 'entity.name.tag'
+  'jsx_closing_element > identifier': 'entity.name.tag'
+  'jsx_self_closing_element > identifier': 'entity.name.tag'

--- a/grammars/tree-sitter-typescript.cson
+++ b/grammars/tree-sitter-typescript.cson
@@ -2,6 +2,7 @@ id: 'typescript'
 name: 'TypeScript'
 type: 'tree-sitter'
 parser: 'tree-sitter-typescript'
+legacyScopeName: 'source.ts'
 
 fileTypes: ['ts', 'tsx']
 

--- a/grammars/tree-sitter-typescript.cson
+++ b/grammars/tree-sitter-typescript.cson
@@ -10,10 +10,10 @@ comments:
 
 folds: [
   {
-    type: ['comment', 'template_string']
+    type: 'comment'
   }
   {
-    type: 'jsx_element'
+    type: ['jsx_element', 'template_string']
     start: {index: 0}
     end: {index: -1}
   }

--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/atom/language-typescript/issues"
+  },
+  "dependencies": {
+    "tree-sitter-typescript": "^0.4.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-typescript",
-  "version": "0.3.0-0",
+  "version": "0.3.0-1",
   "description": "TypeScript language support in Atom",
   "engines": {
     "atom": ">=1.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-typescript",
-  "version": "0.3.0-1",
+  "version": "0.3.0-2",
   "description": "TypeScript language support in Atom",
   "engines": {
     "atom": ">=1.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-typescript",
-  "version": "0.2.3",
+  "version": "0.2.4-0",
   "description": "TypeScript language support in Atom",
   "engines": {
     "atom": ">=1.19.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
     "url": "https://github.com/atom/language-typescript/issues"
   },
   "dependencies": {
-    "tree-sitter-typescript": "^0.4.2"
+    "tree-sitter-typescript": "^0.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-typescript",
-  "version": "0.3.0-2",
+  "version": "0.3.0-3",
   "description": "TypeScript language support in Atom",
   "engines": {
     "atom": ">=1.19.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-typescript",
-  "version": "0.2.4",
+  "version": "0.3.0-0",
   "description": "TypeScript language support in Atom",
   "engines": {
     "atom": ">=1.19.1",


### PR DESCRIPTION
⚠️  Work In Progress ⚠️ 

This adds an alternative TypeScript grammar that uses [tree-sitter-typescript](https://github.com/tree-sitter/tree-sitter-typescript) for parsing instead of [first-mate](https://github.com/atom/first-mate).

It also adds a [Flow](https://flow.org) grammar that is identical to the typescript one except that it matches `.js` files that contain `@flow` near the beginning.