### PR TITLE
Add tree-sitter grammar for TypescriptReact

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@
 Adds syntax highlighting and snippets for TypeScript in Atom.
 
 The grammar is the [Microsoft TypeScript TextMate grammar](https://github.com/Microsoft/TypeScript-TmLanguage) and copied here on a semi-regular basis.  Any issues relating to syntax highlighting are likely to be there.
+
+Any changes made to `tree-sitter-typescript.cson` should be reflected in `tree-sitter-typescript-react.cson`.

--- a/grammars/tree-sitter-typescript-react.cson
+++ b/grammars/tree-sitter-typescript-react.cson
@@ -1,9 +1,9 @@
-name: 'TypeScript'
-scopeName: 'source.ts'
+name: 'TypeScriptReact'
+scopeName: 'source.tsx'
 type: 'tree-sitter'
 parser: 'tree-sitter-typescript'
 
-fileTypes: ['ts']
+fileTypes: ['tsx']
 
 comments:
   start: '// '

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,14 @@
   "requires": true,
   "dependencies": {
     "nan": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
     },
     "tree-sitter-typescript": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.13.5.tgz",
-      "integrity": "sha512-CgPsxcs0Sg/ea3R0tEoHxTTfPzu4TPfCJBAyFGD73MPYuaPbIlOMQjhaNEYf65payh3kbkuBcXLT68My6BF0Fw==",
+      "version": "0.13.6",
+      "resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.13.6.tgz",
+      "integrity": "sha512-1csvCrW5gf4d4D0ZXCctsVDr0M+fOCXYfX/Tve6OAeHUdFu0JsI+CEsS6X3VH7umX5/62RDYe1cwbvOhCuIiXA==",
       "requires": {
         "nan": "^2.10.0"
       }


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

The Theia Typescript Language Server (used by ide-typescript) excepts a language name of TypescriptReact for `.tsx` files. So, I created a copy of the existing tree-sitter grammar and just changed around the names and expected file types.

### Alternate Designs

None.

### Benefits

ide-typescript will start working again.

### Possible Drawbacks

There's a 99% duplicated file now.

### Applicable Issues

Fixes atom/ide-typescript#145