### PR TITLE
Use new TSX-aware TreeSitter grammar

### DIFF
--- a/grammars/tree-sitter-tsx.cson
+++ b/grammars/tree-sitter-tsx.cson
@@ -1,17 +1,9 @@
-name: 'Flow JavaScript'
-scopeName: 'source.flow'
+name: 'TypeScriptReact'
+scopeName: 'source.tsx'
 type: 'tree-sitter'
 parser: 'tree-sitter-typescript/tsx'
 
-fileTypes: [
-  'js'
-  'flow.js'
-  'flow.jsx'
-  'js.flow'
-  'jsx.flow'
-]
-
-contentRegex: '(/\\*([^*]|\\*[^/])*|//.*)(@flow|flow-typed)\\b'
+fileTypes: ['tsx']
 
 comments:
   start: '// '
@@ -54,7 +46,7 @@ folds: [
 ]
 
 scopes:
-  'program': 'source.flow'
+  'program': 'source.ts'
 
   'property_identifier': [
     {
@@ -210,7 +202,7 @@ scopes:
   '"."': 'meta.delimiter.period'
   '","': 'meta.delimiter.comma'
 
-  '"as"': 'keyword.modifier'
+  '"as"': 'keyword.control'
   '"if"': 'keyword.control'
   '"do"': 'keyword.control'
   '"else"': 'keyword.control'

--- a/grammars/tree-sitter-typescript.cson
+++ b/grammars/tree-sitter-typescript.cson
@@ -1,9 +1,9 @@
 name: 'TypeScript'
 scopeName: 'source.ts'
 type: 'tree-sitter'
-parser: 'tree-sitter-typescript'
+parser: 'tree-sitter-typescript/typescript'
 
-fileTypes: ['ts', 'tsx']
+fileTypes: ['ts']
 
 comments:
   start: '// '
@@ -11,16 +11,6 @@ comments:
 folds: [
   {
     type: 'comment'
-  }
-  {
-    type: ['jsx_element', 'template_string']
-    start: {index: 0}
-    end: {index: -1}
-  }
-  {
-    type: 'jsx_self_closing_element'
-    start: {index: 1}
-    end: {index: -2}
   }
   {
     type: [
@@ -70,9 +60,6 @@ scopes:
   ': 'support.type'
 
   '
-    jsx_opening_element > identifier,
-    jsx_closing_element > identifier,
-    jsx_self_closing_element > identifier,
     call_expression > identifier
   ': [
     {
@@ -125,8 +112,6 @@ scopes:
   'hash_bang_line': 'comment.block'
 
   '
-    jsx_expression > "{",
-    jsx_expression > "}",
     template_substitution > "${",
     template_substitution > "}"
   ': 'punctuation.section.embedded'
@@ -226,11 +211,6 @@ scopes:
   '"await"': 'keyword.control'
   '"debugger"': 'keyword.control'
   '"delete"': 'keyword.control'
-
-  'jsx_attribute > property_identifier': 'entity.other.attribute-name'
-  'jsx_opening_element > identifier': 'entity.name.tag'
-  'jsx_closing_element > identifier': 'entity.name.tag'
-  'jsx_self_closing_element > identifier': 'entity.name.tag'
 
   'class > identifier': 'support.storage.type'
   'type_identifier': 'support.storage.type'

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,14 @@
   "requires": true,
   "dependencies": {
     "nan": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA=="
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
     },
     "tree-sitter-typescript": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.13.5.tgz",
-      "integrity": "sha512-CgPsxcs0Sg/ea3R0tEoHxTTfPzu4TPfCJBAyFGD73MPYuaPbIlOMQjhaNEYf65payh3kbkuBcXLT68My6BF0Fw==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.14.0.tgz",
+      "integrity": "sha512-gx54LvIbjIdqSYGwau5G4Kr7j1oEwfWoZDKrR3jUlINEwskNOXaOzgsSdIM92JnFyqdBU+N6mBHpzjafbJ8EFw==",
       "requires": {
         "nan": "^2.10.0"
       }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "url": "https://github.com/atom/language-typescript/issues"
   },
   "dependencies": {
-    "tree-sitter-typescript": "^0.13.6"
+    "tree-sitter-typescript": "^0.14.0"
   }
 }


### PR DESCRIPTION
:pear:'d with @as-cii 

This PR updates our TreeSitter grammar dependency to use a separate grammar for TSX that supports type arguments in JSX expressions. See https://github.com/tree-sitter/tree-sitter-typescript/pull/68 for more details on the change. We need to wait for that PR to land so we can publish a new version and update our dependency in this module. These changes were tested by linking locally.

Fixes #34 
Closes #33 
Fixes atom/ide-typescript#145
