### PR TITLE
fileTypes

### DIFF
--- a/grammars/TypeScript.json
+++ b/grammars/TypeScript.json
@@ -7,6 +7,9 @@
 	"version": "https://github.com/Microsoft/TypeScript-TmLanguage/commit/4daff7b8904bc549dfbee8df1e2f7c82194b9f45",
 	"name": "TypeScript",
 	"scopeName": "source.ts",
+	"fileTypes": [
+		"ts"
+	],
 	"patterns": [
 		{
 			"include": "#directives"

--- a/grammars/TypeScriptReact.json
+++ b/grammars/TypeScriptReact.json
@@ -6,6 +6,9 @@
 	],
 	"version": "https://github.com/Microsoft/TypeScript-TmLanguage/commit/4daff7b8904bc549dfbee8df1e2f7c82194b9f45",
 	"name": "TypeScriptReact",
+	"fileTypes": [
+		"tsx"
+	],
 	"scopeName": "source.tsx",
 	"patterns": [
 		{


### PR DESCRIPTION
### Description of the Change

Looking at the grammar registry code, having the file types in here seems important.

### Alternate Designs

I think without this the user has to set up custom overrides in their config, but that can't be done in the settings UI.

### Benefits

Restore functionality that was lost from pulling in VS Code grammars directly.

### Possible Drawbacks

None.

### Applicable Issues

None yet.