### PR TITLE
Add injectionRegex property to tree-sitter grammar

### DIFF
--- a/grammars/tree-sitter-typescript.cson
+++ b/grammars/tree-sitter-typescript.cson
@@ -5,6 +5,8 @@ parser: 'tree-sitter-typescript/typescript'
 
 fileTypes: ['ts']
 
+injectionRegex: '^ts$|^TS$|typescript|TypeScript'
+
 comments:
   start: '// '
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
This adds an `injectionRegex` to the tree-sitter grammar to support [language injection](https://flight-manual.atom.io/hacking-atom/sections/creating-a-grammar/#language-injection) from other languages. Specifically, for my use case of supporting TS inside of Vue SFC.

I adapted this line from https://github.com/atom/language-javascript/blob/master/grammars/tree-sitter-javascript.cson#L8

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

Other tree-sitter grammars that need to syntax-highlight embedded TS can use this package to do it.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
