### PR TITLE
chore: Update tree-sitter-typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,14 @@
   "requires": true,
   "dependencies": {
     "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
     },
     "tree-sitter-typescript": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.16.1.tgz",
-      "integrity": "sha512-jyU5yl4W6JPn66v2YbzaO1ClDcdDnj+7YQNZz3STgEiUooSjpWI1Ucgw+S/qEGbf0fMXsC0fucpP+/M1uc9ubw==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/tree-sitter-typescript/-/tree-sitter-typescript-0.20.1.tgz",
+      "integrity": "sha512-wqpnhdVYX26ATNXeZtprib4+mF2GlYQB1cjRPibYGxDRiugx5OfjWwLE4qPPxEGdp2ZLSmZVesGUjLWzfKo6rA==",
       "requires": {
         "nan": "^2.14.0"
       }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "url": "https://github.com/atom/language-typescript/issues"
   },
   "dependencies": {
-    "tree-sitter-typescript": "^0.16.1"
+    "tree-sitter-typescript": "^0.20.1"
   }
 }


### PR DESCRIPTION
### Description of the Change

This updates the `tree-sitter-typescript` dependency to it's latest version, which is compatible w/ the latest version of the tree-sitter ABI (ie 13). This is required if Atom is going to update to a newer version tree-sitter, and is a prerequisite for https://github.com/atom/atom/pull/23283.

### Alternate Designs

n/a

### Benefits

Keeps dependencies up to date; allows Atom to keep it's dependencies up to date.

### Possible Drawbacks

If merged, this package will not work with Atom until it also updates to tree-sitter 0.19 or 0.20. This is no different than several other core packages ([language-javascript](https://github.com/atom/language-javascript), [language-css](https://github.com/atom/language-css), [language-go](https://github.com/atom/language-go) and [language-c](https://github.com/atom/language-c) are already updated) that are already updated but not technically compatible w/ Atom's current tree-sitter dependency.

### Applicable Issues

https://github.com/atom/language-python/pull/339, https://github.com/atom/language-shellscript/pull/172, https://github.com/atom/atom/pull/23283, https://github.com/atom/atom/issues/22129, https://github.com/icecream17/atom-update-backlog/blob/main/Languages.md
